### PR TITLE
PHP CS Fixer: replace usage of deprecated ruleset

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -6,6 +6,6 @@ return (new PhpCsFixer\Config())
     ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRules([
         '@PER-CS' => true,
-        '@PHP82Migration' => true,
+        '@PHP8x2Migration' => true,
     ])
     ->setFinder($finder);


### PR DESCRIPTION
no need for warning on deprecated ruleset usage ;)

btw, you can upgrade to 8.3 ruleset, as your composer.json specifies 8.3 ;)

cheers from Fixer 🎉 